### PR TITLE
allow injecting the ConsoleWrapper to ServerMigration from outside

### DIFF
--- a/core/src/main/java/org/wildfly/migration/core/ServerMigration.java
+++ b/core/src/main/java/org/wildfly/migration/core/ServerMigration.java
@@ -40,6 +40,7 @@ public class ServerMigration {
 
     private Path from;
     private Path to;
+    private ConsoleWrapper console;
     private boolean interactive = true;
 
     /**
@@ -59,6 +60,16 @@ public class ServerMigration {
      */
     public ServerMigration to(Path path) {
         this.to = path;
+        return this;
+    }
+
+    /**
+     * Sets the {@link ConsoleWrapper} to be used during migration. Exposed only for testing.
+     * @param console
+     * @return the server migration after applying the configuration change
+     */
+    public ServerMigration console(ConsoleWrapper console) {
+        this.console = console;
         return this;
     }
 
@@ -87,7 +98,7 @@ public class ServerMigration {
             throw ROOT_LOGGER.serverBaseDirNotSet(TARGET);
         }
 
-        final ConsoleWrapper console = new JavaConsole();
+        final ConsoleWrapper console = this.console != null ? this.console : new JavaConsole();
 
         console.printf("%n");
         console.printf("----------------------------------------------------------%n");


### PR DESCRIPTION
This is done purely for testing purposes (where the test uses the `ServerMigration` class directly, emulating real-world usage as closely as possible without the hassles of starting new process).
